### PR TITLE
Fix database schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_21_161127) do
+ActiveRecord::Schema.define(version: 20200121172327) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
The schema files included wrong information about migration version.
It was saying that 20200121172327_create_tokens.rb wasn't migrated yet,
but it was already migrated and included in schema content.

Fixed by increasing information about last migrated version to
20200121172327