### PR TITLE
Specify versions of node and yarn we use.

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_21_161127) do
+ActiveRecord::Schema.define(version: 20200121172327) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/package.json
+++ b/package.json
@@ -15,5 +15,9 @@
   "devDependencies": {
     "webpack": "^4.41.5",
     "webpack-dev-server": "^3.10.1"
+  },
+  "engines": {
+    "node": "12.16.x",
+    "yarn": "1.22.x"
   }
 }


### PR DESCRIPTION
We need to use the same versions on all machines to avoid any
version related bugs in future.